### PR TITLE
Added support for -1 incdir, -p to indicate NWNDIR is provided on comman...

### DIFF
--- a/nwnnsscomp/nwnnsscomp.cpp
+++ b/nwnnsscomp/nwnnsscomp.cpp
@@ -2116,7 +2116,7 @@ int main (int argc, char *argv [])
 		printf ("  pathspec - semicolon separated list of directories to search for files.\n");
 #else
 		printf ("nwnnsscomp [-cdegloqrsx] [-t#] [-v#][-i incdir] [-p nwndir] infile\n\n");
-		printf ("  nwndir - directory where NWN is installed. (Can be set in env as NWNDIR\n");
+		printf ("  nwndir - directory where NWN is installed. (Can be set in env as NWNDIR)\n");
 		printf ("  incdir - directory where all NWN scripts are located.\n");
 #endif
 		printf ("  infile - name of the input file.\n");


### PR DESCRIPTION
...d line, NWNDIR as environment variable,

-r to print basic message even when -q is specified,  -s and -l to support tracking number of global symbols to ensure code can built with stock toolset compiler. Fixed compiler crash when function is declared but not defined.

Added -O2 to cmake flags since it's about 4x speedup in build time for me.
Doing a whole directory (700+ scripts) : 
real    3m17.442s
user    3m13.370s
sys     0m3.479s

With O2:
real    0m42.729s
user    0m38.448s
sys     0m3.471s

I also added real support for 1.69 (xp3.key was never opened before. You you did not have those three include files - x3_inc_strings/skin/horse in your module but used them things would break).

The include directory either needs to be flat and build by adding all the scripts in patch order (so newer ones overwrite old ones) or contain named directories for each release and patch:
base_data/  xp1_data/  xp1patch_data/  xp2_data/  xp2patch_data/  xp3_data/

I may add support for Shadooow's community patch, which would mean a new dir in that list. Since he uses xp2patch.key there is nothing to change if not using incdir.
