### PR TITLE
Fix crash on declared but not defined function. Add -02 for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif (NOT bison)
 
 
 #set(CMAKE_CXX_FLAGS "-Wall -Wno-unused -Wno-write-strings -Wno-deprecated")
-set(CMAKE_CXX_FLAGS "-w")
+set(CMAKE_CXX_FLAGS "-w -O2")
 
 add_subdirectory(_MathLib)
 add_subdirectory(_NmcLib)

--- a/_NscLib/Nsc.h
+++ b/_NscLib/Nsc.h
@@ -598,11 +598,11 @@ enum NscResult
 bool NscCompilerInitialize (CNwnLoader *pLoader, int nVersion, bool fEnableExtensions);
 NscResult NscCompileScript (CNwnLoader *pLoader, const char *pszName, 
                             unsigned char *pauchData, UINT32 ulSize, bool fAllocated,
-                            int nVersion, bool fEnableOptimizations, bool fIgnoreIncludes, 
+                            int nVersion, bool fEnableOptimizations, bool fIgnoreIncludes, bool fCountSymbols, bool fPrintSymbols,
                             CNwnStream *pCodeOutput, CNwnStream *pDebugOutput, 
                             CNwnStream *pErrorOuput = NULL);
 NscResult NscCompileScript (CNwnLoader *pLoader, const char *pszName, 
-                            int nVersion, bool fEnableOptimizations, bool fIgnoreIncludes, 
+                            int nVersion, bool fEnableOptimizations, bool fIgnoreIncludes, bool fCountSymbols,  bool fPrintSymbols,
                             CNwnStream *pCodeOutput, CNwnStream *pDebugOutput,
                             CNwnStream *pErrorOuput = NULL);
 void NscScriptDecompile (CNwnStream &sStream, 

--- a/_NscLib/NscCodeGenerator.cpp
+++ b/_NscLib/NscCodeGenerator.cpp
@@ -507,6 +507,13 @@ bool CNscCodeGenerator::GenerateOutput (CNwnStream *pCodeOutput,
 		NscSymbol *pSymbol = m_pCtx ->GetSymbol (m_anFunctions [i]);
 		NscSymbolFunctionExtra *pExtra = (NscSymbolFunctionExtra *) 
 			m_pCtx ->GetSymbolData (pSymbol ->nExtra);
+
+		if (pExtra->nFile < 0) {
+			m_pCtx ->GenerateError ("Function \"%s\" has no body defined",
+						pSymbol ->szString);
+			return false;
+		}
+
 		unsigned char *pauchCode = m_pCtx ->GetSymbolData (pExtra ->nCodeOffset);
 		unsigned char *pauchArgData = m_pCtx ->GetSymbolData (
 			pSymbol ->nExtra + sizeof (NscSymbolFunctionExtra));

--- a/_NscLib/NscContext.cpp
+++ b/_NscLib/NscContext.cpp
@@ -76,7 +76,9 @@ CNscContext::CNscContext ()
 	m_fOptReturn = false;
 	m_fOptExpression = false;
 	m_nUsedFiles = 0;
-        m_pErrorStream = NULL;
+        m_pErrorStream = NULL;	
+	m_sSymCount = 0;       
+	m_fSymPrint = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -753,6 +755,10 @@ try_again:;
 				p = strchr (pszTemp, '.');
 				if (p)
 					*p = 0;
+				
+				// make sure we use lower case
+				for (p = pszTemp; *p != '\0'; p++)
+					*p = (char)tolower(*p);
 
 				//
 				// Search the current list of included files and see
@@ -1053,6 +1059,8 @@ void CNscContext::AddVariable (const char *pszIdentifier, NscType nType,
 	{
 		assert (!IsPhase2 ());
 		pSymbol ->ulFlags |= NscSymFlag_Constant;
+		m_sSymCount ++;
+		if (!IsNWScript() && m_fSymPrint) printf("Add const symbol %s, count now %d\n", pszIdentifier,m_sSymCount);
 	}
 	else if (IsGlobalScope ())
 	{
@@ -1060,6 +1068,8 @@ void CNscContext::AddVariable (const char *pszIdentifier, NscType nType,
 		m_anGlobalVars .Add (nSymbol);
 		m_anGlobalDefs .Add (nSymbol);
 		pSymbol ->ulFlags |= NscSymFlag_Global;
+		//m_sSymCount ++;	
+		//if (m_fSymPrint) printf("Add global symbol %s, count now %d\n", pszIdentifier, m_sSymCount);
 	}
 	else 
 	{
@@ -1114,7 +1124,8 @@ NscSymbol *CNscContext::AddPrototype (const char *pszIdentifier,
 	pSymbol ->nCompiledStart = 0xffffffff;
 	pSymbol ->nCompiledEnd = 0xffffffff;
 	size_t nSymbol = m_sSymbols .GetSymbolOffset (pSymbol);
-
+	m_sSymCount ++;
+	if (!IsNWScript() && m_fSymPrint) printf("Add prototype symbol %s, count now %d\n", pszIdentifier, m_sSymCount);
 	//
 	// Count the number of arguments
 	//
@@ -1212,7 +1223,8 @@ void CNscContext::AddStructure (const char *pszIdentifier,
 	pSymbol ->ulFlags = 0;
 	pSymbol ->nStackOffset = 0;
 	size_t nSymbol = m_sSymbols .GetSymbolOffset (pSymbol);
-
+	m_sSymCount ++;
+	if (!IsNWScript() && m_fSymPrint) printf("Add struct symbol %s, count now %d\n", pszIdentifier, m_sSymCount);
 	//
 	// Count the number of elements
 	//

--- a/_NscLib/NscContext.h
+++ b/_NscLib/NscContext.h
@@ -234,6 +234,19 @@ public:
 		return m_anGlobalVars .GetCount ();
 	}
 
+	int GetGlobalSymCount () const
+	{
+		return m_sSymCount;
+	}
+	void  AddGlobalSymCount (int nCount)
+	{
+		m_sSymCount += nCount;
+	}
+	void  SetSymPrint (bool bPrint)
+	{
+		m_fSymPrint = bPrint;
+	}
+
 	// @cmember Get the symbol for the n'th global variable
 
 	NscSymbol *GetGlobalVariable (size_t nIndex)
@@ -744,6 +757,8 @@ protected:
 	// @cmember My symbol table
 
 	CNscSymbolTable			m_sSymbols;
+	int		        	m_sSymCount;	
+	bool		        	m_fSymPrint;
 
 	// @cmember Current scope fence
 

--- a/_NwnLib/NwnArray.h
+++ b/_NwnLib/NwnArray.h
@@ -337,6 +337,7 @@ public:
 		m_ulOffset = 0;
 		m_ulCount = 0;
 		m_ulAlloc = 0;
+		m_pData = NULL;
 	}
 
 	// @cmember General destructor
@@ -389,6 +390,8 @@ public:
 	void RelativePrepare ()
 	{
 		m_ulOffset = 0;
+		m_pData = NULL;
+
 		if (m_ulCount > 0)
 			m_ulAlloc = m_ulCount;
 		else
@@ -505,7 +508,8 @@ public:
 
 		if (nNewSize == 0)
 		{
-			if (m_pData != NULL)
+				if (m_pData != NULL)
+			//if (m_ulOffset != 0 && m_ulCount != 0) 
 			{
 				CallDestructors (m_pData, m_ulCount);
 				free (m_pData);

--- a/_NwnLib/NwnStdLoader.h
+++ b/_NwnLib/NwnStdLoader.h
@@ -87,7 +87,7 @@ public:
 
 	// @cmember Initialize the loader
 
-	bool Initialize (const char *pszNwnDir = NULL);
+	bool Initialize (const char *pszNwnDir = NULL, const char * pszIncDir = NULL);
 
 	// @cmember Load a resource
 
@@ -193,9 +193,14 @@ protected:
 
 	std::string				m_strDefaultDir;
 
+	// @cmember script include directiry
+
+	std::string                             m_strIncludeDir;
+	bool                                    m_bUseInclude;
+
 	// @cmember NWN key file
 
-	CNwnKeyFile				m_asKeyFiles [6];
+	CNwnKeyFile				m_asKeyFiles [7];
 
 	// @cmember If true, override is enabled
 

--- a/nwnnsscomp/nwnnsscomp.cpp
+++ b/nwnnsscomp/nwnnsscomp.cpp
@@ -65,6 +65,10 @@ bool g_fCompile = true;
 bool g_fExtract = false;
 bool g_fOptimize = false;
 bool g_fEnableExtensions = false;
+bool g_bNWNDir = false;
+bool g_bInclude = false;
+bool g_bSymbolList = false;
+bool g_bSymbolCount = false;
 int g_nTest = 0;
 int g_nVersion = 999999;
 
@@ -953,7 +957,7 @@ void Test1Callback (const char *pszName, int nIndex)
 	CNwnMemoryStream sOut;
 	CNwnMemoryStream sDbg;
 	NscResult nResult = NscCompileScript (&g_sLoader, 
-		pszName, g_nVersion, false, true, &sOut, &sDbg);
+					      pszName, g_nVersion, false, true, true, false, &sOut, &sDbg);
 
 	//
 	// If we have a success
@@ -1065,7 +1069,7 @@ void Test3Callback (const char *pszName, int nIndex)
 
 	CNwnMemoryStream sOut;
 	NscResult nResult = NscCompileScript (&g_sLoader, 
-		pszName, g_nVersion, true, true, &sOut, NULL);
+					      pszName, g_nVersion, true, true, true, false,  &sOut, NULL);
 
 	//
 	// If we have a success
@@ -1176,7 +1180,7 @@ void DoTest4 (const char *pszName)
 	CNwnMemoryStream sDbg;
 	NscResult nResult = NscCompileScript (&g_sLoader, pszName, 
 		pauchData, ulSize, true, g_nVersion, false, true, 
-		&sOut, &sDbg);
+					      true, false, &sOut, &sDbg);
 
 	//
 	// If we have a success
@@ -1561,13 +1565,13 @@ const char *MakeOutFile (const char *pszInFile, const char *pszOutFile,
 //-----------------------------------------------------------------------------
 
 bool Compile (unsigned char *pauchData, UINT32 ulSize, 
-	const char *pszInFile, const char *pszOutFile, const bool bDebug)
+	      const char *pszInFile, const char *pszOutFile, const bool bDebug, const bool bReport)
 {
 	//
 	// Issue message
 	//
 
-	if (!g_bQuiet) printf ("Compiling: %s\n", pszInFile);
+	if (!g_bQuiet || bReport) printf ("Compiling: %s\n", pszInFile);
 
 	//
 	// Extract the default dir
@@ -1594,7 +1598,7 @@ bool Compile (unsigned char *pauchData, UINT32 ulSize,
 	CNwnMemoryStream sOut;
 	CNwnMemoryStream sDbg;
 	NscResult nResult = NscCompileScript (&g_sLoader, pszInFile, 
-		pauchData, ulSize, true, g_nVersion, g_fOptimize, true, 
+		pauchData, ulSize, true, g_nVersion, g_fOptimize, true,  g_bSymbolCount, g_bSymbolList, 
 		&sOut, &sDbg);
 
 	//
@@ -1705,7 +1709,7 @@ bool Decompile (unsigned char *pauchData, UINT32 ulSize,
 //
 //-----------------------------------------------------------------------------
 
-int Wildcard (const char *pszInFile, const char *pszOutFile, const bool bDebug)
+int Wildcard (const char *pszInFile, const char *pszOutFile, const bool bDebug, const bool bReport)
 {
         bool noError = true;
 
@@ -1785,7 +1789,7 @@ int Wildcard (const char *pszInFile, const char *pszOutFile, const bool bDebug)
 		//
 
 		if (g_fCompile)
-			noError = noError && Compile (pauchData, ulSize, sFind .name, pszOutFile, bDebug);
+			noError = noError && Compile (pauchData, ulSize, sFind .name, pszOutFile, bDebug, bReport);
 		else
 			noError = noError && Decompile (pauchData, ulSize, sFind .name, pszOutFile);
 		nCount++;
@@ -1814,7 +1818,7 @@ int Wildcard (const char *pszInFile, const char *pszOutFile, const bool bDebug)
 	//
 
 	if (g_fCompile)
-		noError = noError && Compile (pauchData, ulSize, pszInFile, pszOutFile, bDebug);
+		noError = noError && Compile (pauchData, ulSize, pszInFile, pszOutFile, bDebug, bReport);
 	else
 		noError = noError && Decompile (pauchData, ulSize, pszInFile, pszOutFile);
 	return noError;
@@ -1898,10 +1902,13 @@ bool MatchPattern (const char *pszString, const char *pszPattern)
 int main (int argc, char *argv [])
 {
 	char *pszOutFile = NULL;
-	char *pszNWNDir = NULL;
+	char *pszNWNDir = NULL;	
+	char *pszIncDir = NULL;
 	char **papszInFiles = NULL;
 	int nInFileCount = 0;
-	bool bDebug = true;
+	bool bDebug = false;
+	bool bReport = false;
+
 	//std::string* strSearchDirs = NULL;
 
 	//
@@ -1975,9 +1982,23 @@ int main (int argc, char *argv [])
 					case 'g':
 						bDebug = false;
 						break;
+				        case 'p':
+						// get the nwndir argument
+						g_bNWNDir = true;
+						break;
 					case 'q':
 						g_bQuiet = true;
 						break;
+				        case 'r':
+						bReport = true;
+						break;
+				        case 'l': // List all global symbols 
+						g_bSymbolList = true;
+						break;
+					case 's':
+						// count of global symbols
+						g_bSymbolCount = true;
+						break;	
 					case 'v':
 						{
 							g_nVersion = 0;
@@ -2009,18 +2030,21 @@ int main (int argc, char *argv [])
 								g_nTest = c - '0';
 						}
 						break;
-					/*case 'i':
+					case 'i':
 					case 'I':
 						++skip;
-
+						pszIncDir =  argv [i + skip];
+						g_bInclude = true;
+ 
+						/*
 						if (strSearchDirs == NULL)
 							strSearchDirs = new std::string(argv[i + skip]);
 						else {
 							strSearchDirs->append(";");
 							strSearchDirs->append(argv[i + skip]);
 						}
-
-						break;*/
+						*/
+						break;
 					default:
 						printf ("Error: Unrecognized option \"%c\"\n", *p);
 						fError = true;
@@ -2049,7 +2073,7 @@ int main (int argc, char *argv [])
 			break;
 		}
 #else
-		else if (pszNWNDir == NULL)
+		else if (g_bNWNDir && pszNWNDir == NULL)
 		{
 			pszNWNDir = argv[i];
 		}
@@ -2058,6 +2082,23 @@ int main (int argc, char *argv [])
 			papszInFiles [nInFileCount++] = argv [i];
 		}
 #endif
+	}
+	if (pszNWNDir == NULL) {
+		if (g_bNWNDir) {
+			fError = true;
+			printf("No NWNDir given\n");
+		} else {
+			// get the NWNDir from ENV
+			pszNWNDir = getenv("NWNDIR");
+			if (pszNWNDir == NULL || strlen(pszNWNDir) == 0) {
+				if ( g_bInclude)
+					pszNWNDir = "/tmp";
+				else {
+					fError = true;
+					printf("No NWNDIR argument, no NWNDIR environment variable and no incdir - cannot proceed.\n");
+				}
+			}
+		}
 	}
 
 	//
@@ -2072,8 +2113,9 @@ int main (int argc, char *argv [])
 		printf ("nwnnsscomp [-cdegoqx] [-t#] [-v#] infile [outfile]\n\n");
 		printf ("  pathspec - semicolon separated list of directories to search for files.\n");
 #else
-		printf ("nwnnsscomp [-cdegoqx] [-t#] [-v#] nwndir infile\n\n");
-		printf ("  nwndir - directory where NWN is installed.\n");
+		printf ("nwnnsscomp [-cdegloqrsx] [-t#] [-v#][-i incdir] [-p nwndir] infile\n\n");
+		printf ("  nwndir - directory where NWN is installed. (Can also be set in env as NWNDIR)\n");
+		printf ("  incdir - directory where all NWN scripts are located.\n");
 #endif
 		printf ("  infile - name of the input file.\n");
 #ifdef _WIN32
@@ -2082,15 +2124,24 @@ int main (int argc, char *argv [])
 		printf ("  -c - Compile the script (default)\n");
 		printf ("  -d - Decompile the script (can't be used with -c)\n");
 		printf ("  -e - Enable non-Bioware extensions\n");
-		printf ("  -g - Don't produce ndb debug file\n");
+		printf ("  -g - Don't produce ndb debug file\n");	
+		printf ("  -i - Path to include dir is following non-switch argument\n");	
+		printf ("  -l - List constant, struct and function symbols and running total\n");
 		printf ("  -o - Optimize the compiled source\n");
+		printf ("  -p - Path to NWNDir is following non-switch argument\n");
 		printf ("  -q - Silence most messages\n");
+		printf ("  -r - report basic status even when quiet (e.g. Compiling foo.nss)\n");
+		printf ("  -s - print symbol count for compiled unit\n");
 		printf ("  -x - Extract script from NWN data files\n");
 		printf ("  -vx.xx - Set the version of the compiler\n");
 		printf ("  -t1 - Perform a compilation test with BIF scripts\n");
 		printf ("  -t2 - Perform a compilation test with the given module\n");
 		printf ("  -t3 - Optimization space saving report with the given module\n");
 		printf ("  -t4 - Perform a compilation test with the given file or files\n");
+		printf ("  Note: the include dir can either be a flat directory with all the files\n");
+		printf ("        extracted in the right order (so later ones overwrite earlier ones) or\n");
+		printf ("        it may contain a subdirectory for each set of scripts. These must be named\n");
+		printf ("        base_data  xp1_data  xp1patch_data  xp2_data  xp2patch_data  xp3_data\n");
 		exit (0);
 	}
 
@@ -2106,8 +2157,9 @@ int main (int argc, char *argv [])
 	//
 	// We must be able to open the file
 	//
-	
-	if (!g_sLoader .Initialize (pszNWNDir))
+	if (!g_bQuiet)
+		printf("NWNNsscompiler initializing with NWNDIR = %s, IncludeDir = %s\n", pszNWNDir, pszIncDir);
+	if (!g_sLoader .Initialize (pszNWNDir, pszIncDir))
 	{
 		printf ("Unable to locate or open Neverwinter Nights\n");
 		exit (1);
@@ -2154,7 +2206,7 @@ int main (int argc, char *argv [])
 
 		g_fCompile = true;
 		EnumScripts (Test1Callback);
-		printf ("Finished with %d scristandardpts, %d failures, and %d mismatches\n",
+		printf ("Finished with %d scripts, %d failures, and %d mismatches\n",
 			g_nCount, g_nFailures, g_nMismatches);
 	}
 
@@ -2329,7 +2381,7 @@ int main (int argc, char *argv [])
 				{
 					strcat (szName, g_fCompile ? ".nss" : ".ncs");
 					if (g_fCompile)
-						Compile (pauchData, ulSize, szName, pszOutFile, bDebug);
+						Compile (pauchData, ulSize, szName, pszOutFile, bDebug, false);
 					else
 						Decompile (pauchData, ulSize, szName, pszOutFile);
 					nCount++;
@@ -2398,13 +2450,13 @@ int main (int argc, char *argv [])
                         //indicating whether any error occurred
                         //on windows it returns the number of files compiled 
                         //- errors are not reported in the return code
-				nCount = Wildcard (szInFile, pszOutFile, bDebug);
+				nCount = Wildcard (szInFile, pszOutFile, bDebug, bReport);
 			}
 			else
-				nCount = Wildcard (papszInFiles[i], pszOutFile, bDebug);
+				nCount = Wildcard (papszInFiles[i], pszOutFile, bDebug, bReport);
 			if (!nCount)
 			{
-                            if (!g_bQuiet) printf ("Errors occurred in compiling \"%s\"\n", papszInFiles[i]);
+                            if (!g_bQuiet || bReport) printf ("Errors occurred in compiling \"%s\"\n", papszInFiles[i]);
                             exit (1);
 			}
 		}


### PR DESCRIPTION
performance. Add -i for include dir support. Add -s and -l for constant
symbol counting. Add -r to allow minimal report of progress even when
"quiet".  Allow for NWNDIR to be specified as an environment variable.

Trying again. This is more work that it should be :)
